### PR TITLE
Update LanguageClient-neovim diagnostics display

### DIFF
--- a/autoload/SpaceVim/layers/lsp.vim
+++ b/autoload/SpaceVim/layers/lsp.vim
@@ -32,19 +32,31 @@ function! SpaceVim#layers#lsp#config() abort
   let g:LanguageClient_diagnosticsDisplay = {
         \ 1: {
         \ 'name': 'Error',
+        \ 'texthl': 'LanguageClientError',
         \ 'signText': g:spacevim_error_symbol,
+        \ 'signTexthl': 'LanguageClientError', 
+        \ 'virtualTexthl': 'Error',
         \ },
         \ 2: {
         \ 'name': 'Warning',
+        \ 'texthl': 'LanguageClientWarning',
         \ 'signText': g:spacevim_warning_symbol,
+        \ 'signTexthl': 'LanguageClientWarningSign',
+        \ 'virtualTexthl': 'Todo',
         \ },
         \ 3: {
         \ 'name': 'Information',
+        \ 'texthl': 'LanguageClientInfo',
         \ 'signText': g:spacevim_info_symbol,
+        \ 'signTexthl': 'LanguageClientInfoSign',
+        \ 'virtualTexthl': 'Todo',
         \ },
         \ 4: {
         \ 'name': 'Hint',
+        \ 'texthl': 'LanguageClientInfo',
         \ 'signText': g:spacevim_info_symbol,
+        \ 'signTexthl': 'LanguageClientInfoSign',
+        \ 'virtualTexthl': 'Todo',
         \ },
         \ }
 


### PR DESCRIPTION
### PR Prelude

Thank you for working on SpaceVim! :)

Please complete these steps and check these boxes before filing your PR:

- [x] I have read and understood SpaceVim's [CONTRIBUTING](https://github.com/SpaceVim/SpaceVim/blob/master/CONTRIBUTING.md) document.
- [x] I have read and understood SpaceVim's [CODE_OF_CONDUCT](https://github.com/SpaceVim/SpaceVim/blob/master/CODE_OF_CONDUCT.md) document.
- [x] I understand my PR may be closed if it becomes obvious I didn't actually perform all of these steps.

### Why this change is necessary and useful?

[Please explain **in detail** why the changes in this PR are needed.]

This fixes LanguageClient Logging and Language Server start failures in neovim and latest LanguageClient-neovim.
The root cause is LanguageClient returning
`{"jsonrpc":"2.0","error":{"code":-32603,"message":"missing field `virtualTexthl`"},"id":1}`
This PR adds the missing `virtualTexhl` config and adds all default settings from LanguageClient-neovim doc.
